### PR TITLE
fix: changed imports for squad_utlis tokenizers

### DIFF
--- a/vae/squad_utils.py
+++ b/vae/squad_utils.py
@@ -9,7 +9,8 @@ from copy import deepcopy
 
 import json_lines
 import numpy as np
-from transformers.tokenization_bert import BasicTokenizer, whitespace_tokenize
+from transformers.models.bert import BasicTokenizer
+from transformers.data.processors.squad import whitespace_tokenize
 from tqdm import tqdm
 
 


### PR DESCRIPTION
To accommodate changes from the latest transformers library  BasicTokenizer,whitespace_tokenize imports were changed.